### PR TITLE
Fix editorial team display on About page

### DIFF
--- a/templates/frontend/pages/editorialTeam.tpl
+++ b/templates/frontend/pages/editorialTeam.tpl
@@ -21,7 +21,7 @@
 	</div>
 	{* /Page Title *}
 
-	{$currentJournal->getLocalizedSetting('masthead')}
+	{$currentJournal->getLocalizedSetting('editorialTeam')}
 </div><!-- .page -->
 
 {include file="common/frontend/footer.tpl"}


### PR DESCRIPTION
I think the setting_name for this block was changed at some point in the journal_settings table from "masthead" to "editorialTeam". This should fix things up for 3.1.1.