### PR TITLE
pkp/pkp-lib#3949 Use Smarty continue/break constructs

### DIFF
--- a/templates/frontend/components/navigationMenu.tpl
+++ b/templates/frontend/components/navigationMenu.tpl
@@ -17,7 +17,7 @@
 	<ul id="{$id|escape}" class="{$ulClass|escape}">
 		{foreach key=field item=navigationMenuItemAssignment from=$navigationMenu->menuTree}
 			{if !$navigationMenuItemAssignment->navigationMenuItem->getIsDisplayed()}
-				{php}continue;{/php}
+				{continue}
 			{/if}
 			{assign var="hasChildren" value=false}
 			{if !empty($navigationMenuItemAssignment->children)}

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -77,7 +77,7 @@
 				{* DOI (requires plugin) *}
 				{foreach from=$pubIdPlugins item=pubIdPlugin}
 					{if $pubIdPlugin->getPubIdType() != 'doi'}
-						{php}continue;{/php}
+						{continue}
 					{/if}
 					{if $issue->getPublished()}
 						{assign var=pubId value=$article->getStoredPubId($pubIdPlugin->getPubIdType())}
@@ -201,7 +201,7 @@
 				{* PubIds (requires plugins) *}
 				{foreach from=$pubIdPlugins item=pubIdPlugin}
 					{if $pubIdPlugin->getPubIdType() == 'doi'}
-						{php}continue;{/php}
+						{continue}
 					{/if}
 					{if $issue->getPublished()}
 						{assign var=pubId value=$article->getStoredPubId($pubIdPlugin->getPubIdType())}

--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -67,7 +67,7 @@
 					{if $primaryGenreIds}
 						{assign var="file" value=$galley->getFile()}
 						{if !$galley->getRemoteUrl() && !($file && in_array($file->getGenreId(), $primaryGenreIds))}
-							{php}continue;{/php}
+							{continue}
 						{/if}
 					{/if}
 					{assign var="hasArticleAccess" value=$hasAccess}

--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -47,7 +47,7 @@
 			<div class="media-list">
 				{foreach name=announcements from=$announcements item=announcement}
 					{if $smarty.foreach.announcements.iteration > $numAnnouncementsHomepage}
-						{php}break;{/php}
+						{break}
 					{/if}
 					{include file="frontend/objects/announcement_summary.tpl" heading="h3"}
 				{/foreach}


### PR DESCRIPTION
Use Smarty3 `{break}`/`{continue}` constructs instead of `{php}break{/php}`/`{php}continue{/php}`. (`{php}` is not a safe construct and requires the user of the `SmartyBC` "backwards compatibility" class.)

OJS 3.1.x uses Smarty2, which *does not* support `{break}`/`{continue}`, so once this is merged it will not work with OJS older than 3.2.

OJS 3.2 no longer uses the `SmartyBC` class, so it will not work *until* this is merged.

Recommendation: Create a `ojs-stable-3_1_1` branch in this repo for 3.1.x compatibility. Then merge this PR into the `master` branch.