### PR TITLE
Fix editLink params in file submissions.tpl

### DIFF
--- a/templates/frontend/pages/submissions.tpl
+++ b/templates/frontend/pages/submissions.tpl
@@ -67,7 +67,7 @@
 		<div class="author_guidelines">
 			<h2 class="page-header">
 				{translate key="about.authorGuidelines"}
-				{include file="frontend/components/editLink.tpl" page="management" op="settings" path="journal" anchor="guidelines" sectionTitleKey="about.authorGuidelines"}
+				{include file="frontend/components/editLink.tpl" page="management" op="settings" path="publication" anchor="submissionStage" sectionTitleKey="about.authorGuidelines"}
 			</h2>
 			{$currentJournal->getLocalizedSetting('authorGuidelines')}
 		</div>
@@ -79,7 +79,7 @@
 		<div class="copyright-notice">
 			<h2 class="page-header">
 				{translate key="about.copyrightNotice"}
-				</span>{include file="frontend/components/editLink.tpl" page="management" op="settings" path="journal" anchor="policies" sectionTitleKey="about.copyrightNotice"}
+				</span>{include file="frontend/components/editLink.tpl" page="management" op="settings" path="distribution" anchor="permissions" sectionTitleKey="about.copyrightNotice"}
 			</h2>
 			{$currentJournal->getLocalizedSetting('copyrightNotice')}
 		</div>


### PR DESCRIPTION
This patch fixes two editLink calls with wrong parameters.
The links to edit "Author Guidelines" and "Copyright Notice" are changed at least in 3.1.x