### PR TITLE
Updated pkpLink in footer

### DIFF
--- a/templates/frontend/components/footer.tpl
+++ b/templates/frontend/components/footer.tpl
@@ -37,9 +37,9 @@
 				{/if}
 
 				<div class="col-md-2" role="complementary">
-					<a href="{$pkpLink}">
-						<img class="img-responsive" alt="{translate key="common.publicKnowledgeProject"}" src="{$baseUrl}/{$brandImage}">
-					</a>
+					<a href="{url page="about" op="aboutThisPublishingSystem"}">
+                                                <img class="img-responsive" alt="{translate key="about.aboutThisPublishingSystem"}" src="{$baseUrl}/{$brandImage}">
+                                        </a>
 				</div>
 
 			</div> <!-- .row -->


### PR DESCRIPTION
Made the PKP footer link point to the "About this publishing system" page like it does in the default theme. Right now the href tag is blank.