### PR TITLE
Fixing Article Subject section in detail page

### DIFF
--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -195,13 +195,17 @@
 				{/foreach}
 
 				{* Article Subject *}
-				{if $article->getLocalizedSubject()}
+				{if !empty($keywords[$currentLocale])}
 					<div class="panel panel-default subject">
 						<div class="panel-heading">
 							{translate key="article.subject"}
 						</div>
 						<div class="panel-body">
-							{$article->getLocalizedSubject()|escape}
+							{foreach from=$keywords item=keyword}
+                						{foreach name=keywords from=$keyword item=keywordItem}
+                  						{$keywordItem|escape}{if !$smarty.foreach.keywords.last}, {/if}
+                						{/foreach}
+              						{/foreach}
 						</div>
 					</div>
 				{/if}


### PR DESCRIPTION
The method getLocalizedSubject() is not working because we should use the $keywords verification. Fixing using the same code from keywords section.
This will fix this isse: NateWr#132