### PR TITLE
Fix broken long urls in reference section of article page

### DIFF
--- a/styles/bootstrap.less
+++ b/styles/bootstrap.less
@@ -256,3 +256,11 @@ footer[role="contentinfo"] {
 .form-control-required {
   color: @brand-danger;
 }
+
+.references a {
+  // Avoid long links overflow
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+  word-break: break-word;
+}


### PR DESCRIPTION
Hi @NateWr , I´ve created a branch dedicate to fix only the long url breaking issue. I´m sorry for the mess, but the first time I did everything in browser and I was not used to it. I followed the regular workflow you suggested and I hope it´s everything fine now.
I am using the CSS from here: https://github.com/pkp/pkp-docs/pull/263/files as you suggested.

Please, let me know whether I should close the other PR.