### PR TITLE
Fixing article subject section from getLocalizedSubject() method

### DIFF
--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -226,18 +226,6 @@
 					{/if}
 				{/foreach}
 
-				{* Article Subject *}
-				{if $article->getLocalizedSubject()}
-					<div class="panel panel-default subject">
-						<div class="panel-heading">
-							{translate key="article.subject"}
-						</div>
-						<div class="panel-body">
-							{$article->getLocalizedSubject()|escape}
-						</div>
-					</div>
-				{/if}
-
 				{* Issue article appears in *}
 				<div class="panel panel-default issue">
 					<div class="panel-heading">


### PR DESCRIPTION
The method getLocalizedSubject() is not working because we should use the $keywords verification. Fixing using the same code from keywords section.