### PR TITLE
Download citation formats fix for article_details.tpl file

### DIFF
--- a/BootstrapThreeThemePlugin.inc.php
+++ b/BootstrapThreeThemePlugin.inc.php
@@ -135,6 +135,19 @@ class BootstrapThreeThemePlugin extends ThemePlugin {
 			$jquery = $request->getBaseUrl() . '/lib/pkp/lib/vendor/components/jquery/jquery' . $min . '.js';
 			$jqueryUI = $request->getBaseUrl() . '/lib/pkp/lib/vendor/components/jqueryui/jquery-ui' . $min . '.js';
 		}
+		
+		// Load icon font FontAwesome - http://fontawesome.io/
+		if (Config::getVar('general', 'enable_cdn')) {
+			$url = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css';
+		} else {
+			$url = $request->getBaseUrl() . '/lib/pkp/styles/fontawesome/fontawesome.css';
+		}
+		$this->addStyle(
+			'fontAwesome',
+			$url,
+			array('baseUrl' => '')
+		);
+		
 		// Use an empty `baseUrl` argument to prevent the theme from looking for
 		// the files within the theme directory
 		$this->addScript('jQuery', $jquery, array('baseUrl' => ''));

--- a/BootstrapThreeThemePlugin.inc.php
+++ b/BootstrapThreeThemePlugin.inc.php
@@ -135,19 +135,6 @@ class BootstrapThreeThemePlugin extends ThemePlugin {
 			$jquery = $request->getBaseUrl() . '/lib/pkp/lib/vendor/components/jquery/jquery' . $min . '.js';
 			$jqueryUI = $request->getBaseUrl() . '/lib/pkp/lib/vendor/components/jqueryui/jquery-ui' . $min . '.js';
 		}
-		
-		// Load icon font FontAwesome - http://fontawesome.io/
-		if (Config::getVar('general', 'enable_cdn')) {
-			$url = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css';
-		} else {
-			$url = $request->getBaseUrl() . '/lib/pkp/styles/fontawesome/fontawesome.css';
-		}
-		$this->addStyle(
-			'fontAwesome',
-			$url,
-			array('baseUrl' => '')
-		);
-		
 		// Use an empty `baseUrl` argument to prevent the theme from looking for
 		// the files within the theme directory
 		$this->addScript('jQuery', $jquery, array('baseUrl' => ''));

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -240,7 +240,20 @@
 											</a>
 										</li>
 									{/foreach}
-							  </ul>
+									 {* Download citation formats *}
+									{if count($citationDownloads)}
+										<div class="panel-heading">{translate key="submission.howToCite.downloadCitation"}</div>
+										
+											{foreach from=$citationDownloads item="citationDownload"}
+												<li>
+													<a href="{url page="citationstylelanguage" op="download" path=$citationDownload.id params=$citationArgs}">
+														<span class="fa fa-download"></span>
+														{$citationDownload.title|escape}
+													</a>
+												</li>
+											{/foreach}
+									{/if}	
+							  </ul>		
 							</div>
 						</div>
 					</div>

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -240,21 +240,26 @@
 											</a>
 										</li>
 									{/foreach}
-									 {* Download citation formats *}
-									{if count($citationDownloads)}
-										<div class="panel-heading">{translate key="submission.howToCite.downloadCitation"}</div>
-										
-											{foreach from=$citationDownloads item="citationDownload"}
-												<li>
-													<a href="{url page="citationstylelanguage" op="download" path=$citationDownload.id params=$citationArgs}">
-														<span class="fa fa-download"></span>
-														{$citationDownload.title|escape}
-													</a>
-												</li>
-											{/foreach}
-									{/if}	
 							  </ul>		
 							</div>
+							{if count($citationDownloads)}
+							<div class="btn-group">
+							  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-controls="cslCitationFormats">
+							    {translate key="submission.howToCite.downloadCitation"}
+									<span class="caret"></span>
+							  </button>
+							  {* Download citation formats *}
+							  <ul class="dropdown-menu" role="menu">
+									{foreach from=$citationDownloads item="citationDownload"}
+										<li>
+											<a href="{url page="citationstylelanguage" op="download" path=$citationDownload.id params=$citationArgs}">
+												<span class="fa fa-download"></span>
+												{$citationDownload.title|escape}
+											</a>
+									{/foreach}
+							  </ul>		
+							</div>
+							{/if}
 						</div>
 					</div>
 				{/if}

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -224,7 +224,7 @@
 							</div>
 							<div class="btn-group">
 							  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-controls="cslCitationFormats">
-							    {translate key="submission.howToCite.citationFormats"}
+								{translate key="submission.howToCite.citationFormats"}
 									<span class="caret"></span>
 							  </button>
 							  <ul class="dropdown-menu" role="menu">
@@ -242,22 +242,22 @@
 									{/foreach}
 							  </ul>		
 							</div>
-							{if count($citationDownloads)}
+							{if !empty($citationDownloads)}
 							<div class="btn-group">
-							  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-controls="cslCitationFormats">
-							    {translate key="submission.howToCite.downloadCitation"}
-									<span class="caret"></span>
-							  </button>
-							  {* Download citation formats *}
-							  <ul class="dropdown-menu" role="menu">
-									{foreach from=$citationDownloads item="citationDownload"}
-										<li>
-											<a href="{url page="citationstylelanguage" op="download" path=$citationDownload.id params=$citationArgs}">
-												<span class="fa fa-download"></span>
-												{$citationDownload.title|escape}
-											</a>
-									{/foreach}
-							  </ul>		
+								<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-controls="cslCitationFormats">
+									{translate key="submission.howToCite.downloadCitation"}
+										<span class="caret"></span>
+								</button>
+							{* Download citation formats *}
+							<ul class="dropdown-menu" role="menu">
+								{foreach from=$citationDownloads item="citationDownload"}
+									<li>
+										<a href="{url page="citationstylelanguage" op="download" path=$citationDownload.id params=$citationArgs}">
+											<span class="fa fa-download"></span>
+											{$citationDownload.title|escape}
+										</a>
+								{/foreach}
+							</ul>		
 							</div>
 							{/if}
 						</div>


### PR DESCRIPTION
For bootstrap3 theme, Ojs 3.2.1.1, for article's page, the "Download citation" option from citation style language plugin didn't display. Only the "more citation formats" option was visible.

After my fix at the article_details.tpl the "Download citation" option works fine.
Please let me know if you need any further information,
Thank you in advance