### PR TITLE
replace iterate with foreach

### DIFF
--- a/templates/frontend/pages/catalogCategory.tpl
+++ b/templates/frontend/pages/catalogCategory.tpl
@@ -49,13 +49,13 @@
 			{translate key="catalog.category.subcategories"}
 		</h2>
 		<ul>
-			{iterate from=subcategories item=subcategory}
+			{foreach from=$subcategories item=subcategory}
 				<li>
 					<a href="{url op="category" path=$subcategory->getPath()}">
 						{$subcategory->getLocalizedTitle()|escape}
 					</a>
 				</li>
-			{/iterate}
+			{/foreach}
 		</ul>
 	</nav>
 	{/if}

--- a/templates/frontend/pages/indexSite.tpl
+++ b/templates/frontend/pages/indexSite.tpl
@@ -32,7 +32,7 @@
 
 		{else}
 			<ul class="media-list">
-				{iterate from=journals item=journal}
+				{foreach from=$journals item=journal}
 					{capture assign="url"}{url journal=$journal->getPath()}{/capture}
 					{assign var="thumb" value=$journal->getLocalizedData('journalThumbnail')}
 					{assign var="description" value=$journal->getLocalizedDescription()}
@@ -70,7 +70,7 @@
 							</ul>
 						</div>
 					</li>
-				{/iterate}
+				{/foreach}
 			</ul>
 
 			{if $journals->getPageCount() > 0}

--- a/templates/frontend/pages/search.tpl
+++ b/templates/frontend/pages/search.tpl
@@ -86,9 +86,9 @@
 			<h2>
 				{translate key="search.searchResults"}
 			</h2>
-			{iterate from=results item=result}
+			{foreach from=$results item=result}
 				{include file="frontend/objects/article_summary.tpl" article=$result.publishedSubmission journal=$result.journal showDatePublished=true hideGalleys=true}
-			{/iterate}
+			{/foreach}
 		</div>
 
 		{* No results found *}


### PR DESCRIPTION
The journal list on the index site was broken at least for us in OJS 3.3.0-3. Replacing `iterate` with `foreach` should fix this. Haven't tested the other two occurences, but they should work accordingly.