### PR TITLE
remove old paging code

### DIFF
--- a/templates/frontend/pages/indexSite.tpl
+++ b/templates/frontend/pages/indexSite.tpl
@@ -72,13 +72,6 @@
 					</li>
 				{/foreach}
 			</ul>
-
-			{if $journals->getPageCount() > 0}
-				<div class="cmp_pagination">
-					{page_info iterator=$journals}
-					{page_links anchor="journals" name="journals" iterator=$journals}
-				</div>
-			{/if}
 		{/if}
 	</div>
 


### PR DESCRIPTION
Since all journals are now listed, remove old code which will fix:

https://forum.pkp.sfu.ca/t/bootstrap-3-php-fatal-error-uncaught-error-call-to-a-member-function-getpagecount-on-array/