### PR TITLE
Update article_summary.tpl

### DIFF
--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -22,7 +22,7 @@
 <div class="article-summary media">
 	{if $article->getLocalizedCoverImage()}
 		<div class="cover media-left">
-			<a href="{if $journal}{url journal=$journal->getPath() page="article" op="view" path=$articlePath}{else}{url page="article" op="view" path=$articlePath}{/if}" class="file">
+			<a {if $journal}href=“{url journal=$journal->getPath() page=“article” op=“view” path=$articlePath}”{else}href=“{url page=“article” op=“view” path=$articlePath}”{/if} class=“file”>
 				<img class="media-object" src="{$article->getLocalizedCoverImageUrl()|escape}" alt="{$article->getLocalizedCoverImageAltText()|escape|default:''}">
 			</a>
 		</div>


### PR DESCRIPTION
When loading a Cover Image of an article in Publication > Issue, We realized that Bootstrap themes generate invalid URL links in the images of articles in the table of contents.